### PR TITLE
Fix deprecation warning

### DIFF
--- a/client.py
+++ b/client.py
@@ -50,7 +50,7 @@ async def main():
                     print(topic, pretty(message))
 
 try:
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 except KeyboardInterrupt:
     pass
 except ConnectionRefusedError:


### PR DESCRIPTION
```
client.py:53: DeprecationWarning: There is no current event loop
asyncio.get_event_loop().run_until_complete(main())
```